### PR TITLE
Fix fullscreen support for opera.

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -107,7 +107,7 @@ var ui = (function() {
 
 	function onScreenSizeClick( event ) {
 
-		if ( document.fullscreenEnabled === false ) {
+		if ( !document.fullscreenElement ) {
 			enterFullscreen();
 		} else {
 			exitFullscreen();


### PR DESCRIPTION
document.fullscreenEnabled only tells you if the browser supports fullscreen. Use document.fullscreenElement instead to check for fullscreen state (fixes #33)
