### PR TITLE
Add better link behaviour

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -281,6 +281,9 @@ var editor = (function() {
 		document.execCommand( 'unlink', false );
 
 		if (url !== "") {
+		
+			if(url[0].match(/[A-z0-9]/i) && url[0] != "h") url = "http://" + url;
+
 			document.execCommand( 'createLink', false, url );
 		}
 	}


### PR DESCRIPTION
When adding a link in Zenpen, often it gets appended to the current URL.
For example: "www.google.com" produces a link to: "http://www.zenpen.io/www.google.com".

I think this is a bug, I tried to fix it with a line of code that prepends "http://" when needed.
This (partially) fixes #31.
