### PR TITLE
Changing the ret variable scope to local

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -11,7 +11,7 @@ function supportsHtmlStorage() {
 }
 
 function get_text(el) {
-    ret = " ";
+    var ret = " ";
     var length = el.childNodes.length;
     for(var i = 0; i < length; i++) {
         var node = el.childNodes[i];


### PR DESCRIPTION
Why to expose this variable to global scope ? It's not intentionally made, right ?
