### PR TITLE
Added support for IME composition

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -10,6 +10,7 @@ var editor = (function() {
 	function init() {
 
 		lastRange = 0;
+		composing = false;
 		bindElements();
 
 		// Set cursor position
@@ -73,6 +74,11 @@ var editor = (function() {
 				scrollEnabled = true;
 			}), 250);
 		});
+
+		// Composition bindings. We need them to distinguish
+		// IME composition from text selection
+		document.addEventListener( 'compositionstart', onCompositionStart );
+		document.addEventListener( 'compositionend', onCompositionEnd );
 	}
 
 	function bindElements() {
@@ -120,7 +126,7 @@ var editor = (function() {
 		}
 
 		// Text is selected
-		if ( selection.isCollapsed === false ) {
+		if ( selection.isCollapsed === false && composing === false ) {
 
 			currentNodeList = findNodes( selection.focusNode );
 
@@ -335,6 +341,14 @@ var editor = (function() {
 		} else {
 			return text.split(/\s+/).length;
 		}
+	}
+
+	function onCompositionStart ( event ) {
+		composing = true;
+	}
+
+	function onCompositionEnd (event) {
+		composing = false;
 	}
 
 	return {


### PR DESCRIPTION
I added support for IME composition, which is needed to type East Asian characters. The issue was that zenpen recognised typing Japanese characters as selecting text and showed the toolbar. This patch fixes this issue.

Gif animations are attached below to illustrate how IME composition behaves.

**Original**
![before](https://f.cloud.github.com/assets/13040/1340372/690c6582-362d-11e3-9361-ee06c81ce9fd.gif)

**With my patch**
![after](https://f.cloud.github.com/assets/13040/1340373/6e831f24-362d-11e3-8fa8-9978c90277e8.gif)
