### PR TITLE
fix fullscreen api capitalization for Safari

### DIFF
--- a/js/libs/fullScreen.js
+++ b/js/libs/fullScreen.js
@@ -22,7 +22,7 @@
 			webkit: {
 				enabled: "webkitIsFullScreen",
 				element: "webkitCurrentFullScreenElement",
-				request: "webkitRequestFullScreen",
+				request: "webkitRequestFullscreen",
 				exit:    "webkitCancelFullScreen",
 				events: {
 					change: "webkitfullscreenchange",


### PR DESCRIPTION
The webkitRequestFullScreen fullscreen API capitalization doesn't work on Safari 7. Using a lowercase _s_  fixes it.
