### PR TITLE
Null check for empty links on Markdown export.

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -313,17 +313,19 @@ var ui = (function() {
 				
 				var links = text.match(/<a href="(.+)">(.+)<\/a>/gi);
 				
-				for ( var i = 0; i<links.length; i++ ) {
-					var tmpparent = document.createElement('div');
-					tmpparent.innerHTML = links[i];
-					
-					var tmp = tmpparent.firstChild;
-					
-					var href = tmp.getAttribute('href');
-					var linktext = tmp.textContent || tmp.innerText || "";
-					
-					text = text.replace(links[i],'['+linktext+']('+href+')');
-				}
+                                if (links !== null) {
+                                        for ( var i = 0; i<links.length; i++ ) {
+                                                var tmpparent = document.createElement('div');
+                                                tmpparent.innerHTML = links[i];
+                                                
+                                                var tmp = tmpparent.firstChild;
+                                                
+                                                var href = tmp.getAttribute('href');
+                                                var linktext = tmp.textContent || tmp.innerText || "";
+                                                
+                                                text = text.replace(links[i],'['+linktext+']('+href+')');
+                                        }
+                                }
 				
 				text = header +"\n\n"+ text;
 			break;


### PR DESCRIPTION
Exporting Markdown without links gives the following error:

```
Uncaught TypeError: Cannot read property 'length' of null ui.js:316
formatText ui.js:316
selectFormat
```

I just added a null check in case the regex doesn't return any results.

![screenshot 2014-04-23 14 05 27](https://cloud.githubusercontent.com/assets/1297679/2781285/0b49421a-cb12-11e3-9527-226f6b0a9d55.png)
