### PR TITLE
Google fonts protocol-relative URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 		<meta name="description" content="Zenpen - A minimal web based text editor, for the modern man.">
         
 		<!-- CSS -->
-		<link href='http://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+		<link href="//fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic" rel="stylesheet" type="text/css">
 		<link href="css/style.css" rel="stylesheet">
 		<link href="css/fonts.css" rel="stylesheet">
 


### PR DESCRIPTION
To prevent a mixed content warning on HTTPS-websites. Also changed quotation marks for consistency.