### PR TITLE
Add word wrap for long words

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -57,6 +57,7 @@ section {
 header {
 	font-weight: bold;
 	font-size: 38px;
+	word-wrap: break-word;
 }
 
 article {
@@ -66,6 +67,7 @@ article {
 	min-height: 90%;
 	font-size: 22px;
 	display: block;
+	word-wrap: break-word;
 }
 
 blockquote {


### PR DESCRIPTION
Fixes issue #125 

Here's the little bug in action:
![screenshot from 2016-09-12 18 39 52](https://cloud.githubusercontent.com/assets/5942750/18437216/71ce3b5a-7919-11e6-8fe0-d06756de7bed.png)

And here it is after the fix:
![screenshot from 2016-09-12 18 44 50](https://cloud.githubusercontent.com/assets/5942750/18437225/7dcdf792-7919-11e6-8034-108f39a9ac61.png)

