### PR TITLE
Fixed units according to style guide

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -27,8 +27,8 @@ html {
 
 html, body {
 	font-family: 'Lora', serif;
-	padding: 0px;
-	margin: 0px;
+	padding: 0;
+	margin: 0;
 	height: 100%;
 }
 
@@ -74,7 +74,7 @@ blockquote {
 	border-left: 4px solid deepskyblue;
 	margin-left: -19px;
 	padding-left: 15px;
-	margin-right: 0px;
+	margin-right: 0;
 }
 
 .no-overflow {
@@ -111,13 +111,13 @@ blockquote {
 	position: fixed;
 	padding: 20px;
 	width: 65px;
-	bottom: 0px;
-	left: 0px;
-	top: 0px;
+	bottom: 0;
+	left: 0;
+	top: 0;
 }
 
 .ui:hover button {
-	opacity: 0.4;
+	opacity: .4;
 }
 
 .ui button:hover {
@@ -137,11 +137,11 @@ blockquote {
 	cursor: pointer;
 	font-size: 25px;
 	color: inherit;
-	opacity: 0.1;
-	padding: 0px;
+	opacity: .1;
+	padding: 0;
 	height: 32px;
 	width: 25px;
-	border: 0px;
+	border: 0;
 }
 
 a {
@@ -159,8 +159,8 @@ a:hover {
 	height: 100%;
 	width: 100%;
 	z-index: 3;
-	left: 0px;
-	top: 0px;
+	left: 0;
+	top: 0;
 }
 
 .quote {
@@ -173,12 +173,12 @@ a:hover {
  *********************************************/
 
 .yang .modal {
-	background-color: rgba(255,255,255,0.9);
+	background-color: rgba(255,255,255,.9);
 	color: #111;
 }
 
 .modal {
-	background-color: rgba(0,0,0,0.9);
+	background-color: rgba(0,0,0,.9);
 	margin-left: -200px;
 	position: absolute;
 	border-radius: 3px;
@@ -194,8 +194,8 @@ a:hover {
 .modal h1 {
 	text-align: center;
 	font-size: 20px;
-	padding: 0px;
-	margin: 0px;
+	padding: 0;
+	margin: 0;
 }
 
 .modal div {
@@ -216,7 +216,7 @@ a:hover {
 }
 
 .description p {
-	margin-bottom: 0px;
+	margin-bottom: 0;
 	text-align: center;
 }
 
@@ -255,7 +255,7 @@ a:hover {
 }
 
 .saveselection span:hover {
-	background: rgba(255,255,255,0.8);
+	background: rgba(255,255,255,.8);
 	color: black;
 }
 
@@ -273,18 +273,18 @@ a:hover {
 	cursor: pointer;
 	display: block;
 	border: none;
-	padding: 0px;
+	padding: 0;
 	width: 80px;
 	color: #fff;
 	margin-top: -2px;
 }
 
 .savebutton:hover {
-	opacity: 0.7;
+	opacity: .7;
 }
 
 .activesave {
-	background: rgba(255,255,255,0.8);
+	background: rgba(255,255,255,.8);
 	color: black;
 }
 
@@ -304,16 +304,16 @@ a:hover {
 }
 
 .word-counter {
-	box-shadow: inset 0px 0px 9px -2px rgba(0,0,0,0.9);
+	box-shadow: inset 0 0 9px -2px rgba(0,0,0,.9);
 	position: fixed;
 	height: 100%;
 	right: -6px;
 	width: 6px;
-	top: 0px;
+	top: 0;
 }
 
 .word-counter.active {
-	right: 0px;
+	right: 0;
 }
 
 .word-counter .progress {
@@ -325,7 +325,7 @@ a:hover {
 	
 	background-color: deepskyblue;
 	position: absolute;
-	bottom: 0px;
+	bottom: 0;
 	width: 100%;
 	height: 0%;
 }
@@ -350,8 +350,8 @@ a:hover {
 	left: -999px;
 	top: -999px;
 	color: #fff;
-	height: 0px;
-	width: 0px;
+	height: 0;
+	width: 0;
 	z-index: 5;
 	margin-top: 5px;
 	opacity: 0;
@@ -364,11 +364,11 @@ a:hover {
 
 .text-options.active {
 	opacity: 1;
-	margin-top: 0px;
+	margin-top: 0;
 }
 
 .options {
-	background-color: rgba(0,0,0,0.9);
+	background-color: rgba(0,0,0,.9);
 	position: absolute;
 	border-radius: 5px;
 	margin-left: -63px;
@@ -391,9 +391,9 @@ a:hover {
 }
 
 .options.url-mode .bold, .options.url-mode .italic, .options.url-mode .quote {
-	width: 0px;
+	width: 0;
 	overflow: hidden;
-	margin-right: 0px;
+	margin-right: 0;
 	opacity: 0;
 }
 
@@ -410,7 +410,7 @@ a:hover {
 
 	float: left;
 	width: 28px;
-	opacity: 0.7;
+	opacity: .7;
 	height: 30px;
 	border-radius: 3px;
 	margin-right: 1px;
@@ -433,31 +433,31 @@ a:hover {
 
 	border-radius: 3px;
 	overflow: hidden;
-	outline: 0px;
+	outline: 0;
 	height: 30px;
-	padding: 0px;
-	margin: 0px;
-	border: 0px;
+	padding: 0;
+	margin: 0;
+	border: 0;
 	float: left;
-	width: 0px;
+	width: 0;
 }
 
 .options button.active {
-	background-color: rgba(255,255,255,0.4);
+	background-color: rgba(255,255,255,.4);
 	opacity: 1;
 }
 
 .yang .options button.active {
-	background-color: rgba(0,0,0,0.3);
+	background-color: rgba(0,0,0,.3);
 }
 
 .options button:hover {
-	opacity: 0.95;
+	opacity: .95;
 }
 
 .options:before {
 	content: "";
-	border-top: 5px solid rgba(0,0,0,0.9);
+	border-top: 5px solid rgba(0,0,0,.9);
 	border-bottom: 5px solid transparent;
 	border-right: 5px solid transparent;
 	border-left: 5px solid transparent;
@@ -465,17 +465,17 @@ a:hover {
 	margin-left: -5px;
 	bottom: -15px;
 	height: 5px;
-	width: 0px;
+	width: 0;
 	left: 50%;
 }
 
 .yang .options {
-	background-color: rgba(255,255,255,0.9);
+	background-color: rgba(255,255,255,.9);
 	color: #000;
 }
 
 .yang .options:before {
-	border-top: 5px solid rgba(255,255,255,0.9);
+	border-top: 5px solid rgba(255,255,255,.9);
 }
 
 .url {
@@ -484,12 +484,12 @@ a:hover {
 
 .top {
 	position: absolute;
-	top: 0px;
+	top: 0;
 }
 
 .bottom {
 	position: absolute;
-	bottom: 0px;
+	bottom: 0;
 }
 
 .about {


### PR DESCRIPTION
According to [Google's HTML & CSS styleguide](https://google.github.io/styleguide/htmlcssguide.html#0_and_Units),

> Omit unit specification after “0” values, unless required.
> Do not use units after 0 values unless they are required.

you shouldn't use `0px` but instead, remove the units, (just `0`). Also, you should neglect the `0` when using decimal numbers under 1, e.g. (`0.8` should be just `.8`).

I have implemented these rules in the CSS code.