### PR TITLE
Added hyphen to 'bottom left'

### DIFF
--- a/js/default.js
+++ b/js/default.js
@@ -13,6 +13,6 @@ A minimalist writing zone, where you can block out all distractions and get to w
 	Quotes are easy to add too!\
 </blockquote>\
 <p>\
-	For <i>questions</i> and <b>open source info</b>, Click that little question mark at the bottom left of the screen.\
+	For <i>questions</i> and <b>open source info</b>, Click that little question mark at the bottom-left of the screen.\
 </p>\
 <p>Happy Typing! ~ <b>Tim Holman (@twholman)</b></p>';


### PR DESCRIPTION
Bottom-left is coming before the object, `screen`, and so to hyphen it is *technically* right ([source](https://english.stackexchange.com/questions/215262/hyphenation-of-left-hand-side)). The best kind of right, right?

But anyway, I love ZenPen, thanks for making it!