### PR TITLE
fixed url adding bug

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -3,7 +3,7 @@ ZenPen = window.ZenPen || {};
 ZenPen.editor = (function() {
 
 	// Editor elements
-	var headerField, contentField, cleanSlate, lastType, currentNodeList, savedSelection;
+	var headerField, contentField, lastType, currentNodeList, lastSelection;
 
 	// Editor Bubble elements
 	var textOptions, optionsBox, boldButton, italicButton, quoteButton, urlButton, urlInput;
@@ -342,8 +342,11 @@ ZenPen.editor = (function() {
 	}
 
 	function rehighlightLastSelection() {
-
-		window.getSelection().addRange( lastSelection );
+		var selection = window.getSelection();
+		if (selection.rangeCount > 0) {
+			selection.removeAllRanges();
+		}
+		selection.addRange( lastSelection );
 	}
 
 	function getWordCount() {


### PR DESCRIPTION
Currently only Firefox supports multiple selection ranges, other browsers will not add new ranges to the selection if it already contains one.
Ref.: https://developer.mozilla.org/en-US/docs/Web/API/Selection/addRange
also fixed variable names (as well as removed an unused variable)

Issue with the original code:
The link adding feature was broken on recent version on Chrome. (and also on Firefox Dev for some reasons I don't exactly know). After changing (adding) those few lines of codes, the bug appears to be fixed.