### PR TITLE
fix(ui): bug target save modal, add wordcounter, remove bugs description modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,7 @@
 				</div>
 
 				<div class="bottom">
+					<span class="word-counter-container">#<span class="word-counter-value"></span></span>
 					<a
 						class="about"
 						href="https://www.buymeacoffee.com/tholman"

--- a/js/ui.js
+++ b/js/ui.js
@@ -9,7 +9,7 @@ ZenPen.ui = (function() {
 	var screenSizeElement, colorLayoutElement, targetElement, saveElement;
 
 	// Word Counter
-	var wordCountValue, wordCountBox, wordCountElement, wordCounter, wordCounterProgress;
+	var wordCountValue, wordCountBox, wordCountElement, wordCounter, wordCounterProgress, wordCounterContainer, wordCounterValue;
 	
 	//save support
 	var supportsSave, saveFormat, textToWrite;
@@ -41,7 +41,7 @@ ZenPen.ui = (function() {
 			wordCountValue = parseInt(localStorage['wordCount']);
 			wordCountElement.value = localStorage['wordCount'];
 			wordCounter.className = "word-counter active";
-			updateWordCount();
+			setWordCount(wordCountValue);
 		}
 
 		// Activate color switch
@@ -114,6 +114,9 @@ ZenPen.ui = (function() {
 
 		wordCounter = document.querySelector( '.word-counter' );
 		wordCounterProgress = wordCounter.querySelector( '.progress' );
+		wordCounterContainer = document.querySelector( '.word-counter-container' );
+ 		wordCounterContainer.style.display = "none";
+ 		wordCounterValue = document.querySelector( '.word-counter-value' );
 
 		header = document.querySelector( '.header' );
 		header.onkeypress = onHeaderKeyPress;
@@ -147,6 +150,7 @@ ZenPen.ui = (function() {
 	function onTargetClick( event ) {
 		overlay.style.display = "block";
 		wordCountBox.style.display = "block";
+		saveModal.style.display = "none";
 		wordCountElement.focus();
 	}
 
@@ -205,12 +209,14 @@ ZenPen.ui = (function() {
 
 			wordCountValue = count;
 			wordCounter.className = "word-counter active";
+			wordCounterContainer.style.display = "block";
 			updateWordCount();
 
 		} else {
 
 			wordCountValue = 0;
 			wordCounter.className = "word-counter";
+			wordCounterContainer.style.display = "none";
 		}
 		
 		saveState();
@@ -227,6 +233,7 @@ ZenPen.ui = (function() {
 
 		var wordCount = ZenPen.editor.getWordCount();
 		var percentageComplete = wordCount / wordCountValue;
+		wordCounterValue.innerHTML = wordCount;
 		wordCounterProgress.style.height = percentageComplete * 100 + '%';
 
 		if ( percentageComplete >= 1 ) {
@@ -349,7 +356,6 @@ ZenPen.ui = (function() {
 		
 		overlay.style.display = "none";
 		wordCountBox.style.display = "none";
-		descriptionModal.style.display = "none";
 		saveModal.style.display = "none";
 		
 		if ( document.querySelectorAll('span.activesave' ).length > 0) {


### PR DESCRIPTION
Hi Tim, thanks for your simple editor.
Here I fix 2 bugs

- Save Target Modal
<img width="444" alt="image" src="https://user-images.githubusercontent.com/3961872/163090735-b65bdc71-6122-4c9f-8214-d93a229f5c94.png">
If we click target modal, then click save modal, then click target modal again. Save Modal will be showed again. Thus I change its logic of showing

- Description Modal
`descriptionModal` not used anywhere else. So I removed it.

I also add new features in terms of "Wordcounter Value", beside "Wordcounter Progress" I think people would like to see how many words already written. So I add new feature in a container above coffee icon
<img width="56" alt="image" src="https://user-images.githubusercontent.com/3961872/163090930-7c4a3ffc-6b0f-4e90-b97f-a63270487dad.png">
Content will be updated each `updateWordCount` triggered.

Full Screenshot attached
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/3961872/163091144-f50875bd-b18d-4eaa-bb2c-80c054f59f94.png">

Hopefully this feature and bug fixing could enhance your ZenPen.
Cheers.